### PR TITLE
Add STM32F0 GPIO driver and host tests

### DIFF
--- a/CMakeHost/tests/CMakeLists.txt
+++ b/CMakeHost/tests/CMakeLists.txt
@@ -2,3 +2,7 @@
 add_executable(test_sanity test_sanity.c)
 target_link_libraries(test_sanity PRIVATE core)  # 'core' vem do CMakeLists da raiz do CMakeHost
 add_test(NAME sanity COMMAND test_sanity)
+
+add_executable(test_gpio test_gpio.c)
+target_link_libraries(test_gpio PRIVATE core)
+add_test(NAME gpio COMMAND test_gpio)

--- a/CMakeHost/tests/test_gpio.c
+++ b/CMakeHost/tests/test_gpio.c
@@ -1,0 +1,73 @@
+#include <assert.h>
+#include <stdio.h>
+#include "gpio.h"
+
+/* Fakes para os registradores */
+static RCC_TypeDef rcc_fake;
+static GPIO_TypeDef gpioa_fake;
+static GPIO_TypeDef gpiob_fake;
+
+RCC_TypeDef *RCC = &rcc_fake;
+GPIO_TypeDef *GPIOA = &gpioa_fake;
+GPIO_TypeDef *GPIOB = &gpiob_fake;
+
+int main(void) {
+    printf("[gpio] executando testes...\n");
+
+    /* Teste: inicialização como saída */
+    rcc_fake.AHBENR = 0;
+    gpioa_fake.MODER = 0;
+    gpioa_fake.OTYPER = 0xFFFFu;
+    gpioa_fake.OSPEEDR = 0;
+    gpioa_fake.PUPDR = 0xFFFFFFFFu;
+    gpio_init_output(GPIOA, 5);
+    assert((rcc_fake.AHBENR & RCC_AHBENR_GPIOAEN) != 0);
+    assert(((gpioa_fake.MODER >> (5 * 2)) & 0x3u) == 0x1u);
+    assert(((gpioa_fake.OTYPER >> 5) & 0x1u) == 0u);
+    assert(((gpioa_fake.OSPEEDR >> (5 * 2)) & 0x3u) == 0x3u);
+    assert(((gpioa_fake.PUPDR >> (5 * 2)) & 0x3u) == 0x0u);
+
+    /* Teste: write/toggle */
+    gpioa_fake.BSRR = 0;
+    gpio_write(GPIOA, 5, 1);
+    assert(gpioa_fake.BSRR == (1u << 5));
+    gpioa_fake.BSRR = 0;
+    gpio_write(GPIOA, 5, 0);
+    assert(gpioa_fake.BSRR == (1u << (5 + 16)));
+
+    gpioa_fake.ODR = 0;
+    gpio_toggle(GPIOA, 5);
+    assert((gpioa_fake.ODR & (1u << 5)) != 0u);
+    gpio_toggle(GPIOA, 5);
+    assert((gpioa_fake.ODR & (1u << 5)) == 0u);
+
+    /* Teste: inicialização como entrada com pull-up */
+    rcc_fake.AHBENR = 0;
+    gpiob_fake.MODER = 0xFFFFFFFFu;
+    gpiob_fake.PUPDR = 0;
+    gpiob_fake.OTYPER = 0xFFFFFFFFu;
+    gpiob_fake.OSPEEDR = 0xFFFFFFFFu;
+    gpio_init_input(GPIOB, 3, true, false);
+    assert((rcc_fake.AHBENR & RCC_AHBENR_GPIOBEN) != 0);
+    assert(((gpiob_fake.MODER >> (3 * 2)) & 0x3u) == 0x0u);
+    assert(((gpiob_fake.PUPDR >> (3 * 2)) & 0x3u) == 0x1u);
+    assert(((gpiob_fake.OTYPER >> 3) & 0x1u) == 0x0u);
+    assert(((gpiob_fake.OSPEEDR >> (3 * 2)) & 0x3u) == 0x0u);
+
+    /* Teste: entrada com pull-down */
+    gpiob_fake.MODER = 0xFFFFFFFFu;
+    gpiob_fake.PUPDR = 0;
+    gpio_init_input(GPIOB, 4, false, true);
+    assert(((gpiob_fake.MODER >> (4 * 2)) & 0x3u) == 0x0u);
+    assert(((gpiob_fake.PUPDR >> (4 * 2)) & 0x3u) == 0x2u);
+
+    /* Teste: leitura de input */
+    gpiob_fake.IDR = 0;
+    assert(gpio_read_input(GPIOB, 3) == 0u);
+    gpiob_fake.IDR = (1u << 3);
+    assert(gpio_read_input(GPIOB, 3) == 1u);
+
+    printf("[gpio] OK!\n");
+    return 0;
+}
+

--- a/stm32_repo/Drivers/gpio.c
+++ b/stm32_repo/Drivers/gpio.c
@@ -1,0 +1,89 @@
+#include "gpio.h"
+
+#if defined(_MSC_VER)
+#define WEAK_SYMBOL __declspec(selectany)
+#else
+#define WEAK_SYMBOL __attribute__((weak))
+#endif
+
+/* Endereços base reais; nos testes os símbolos fortes substituem estes. */
+WEAK_SYMBOL RCC_TypeDef *RCC   = (RCC_TypeDef *)0x40021000u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOA = (GPIO_TypeDef *)0x48000000u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOB = (GPIO_TypeDef *)0x48000400u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOC = (GPIO_TypeDef *)0x48000800u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOD = (GPIO_TypeDef *)0x48000C00u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOE = (GPIO_TypeDef *)0x48001000u;
+WEAK_SYMBOL GPIO_TypeDef *GPIOF = (GPIO_TypeDef *)0x48001400u;
+
+/* Helper interno para habilitar o clock do port */
+static void gpio_enable_clock(GPIO_TypeDef *port) {
+    if (port == GPIOA) {
+        RCC->AHBENR |= RCC_AHBENR_GPIOAEN;
+    } else if (port == GPIOB) {
+        RCC->AHBENR |= RCC_AHBENR_GPIOBEN;
+    } else if (port == GPIOC) {
+        RCC->AHBENR |= RCC_AHBENR_GPIOCEN;
+    } else if (port == GPIOD) {
+        RCC->AHBENR |= RCC_AHBENR_GPIODEN;
+    } else if (port == GPIOE) {
+        RCC->AHBENR |= RCC_AHBENR_GPIOEEN;
+    } else if (port == GPIOF) {
+        RCC->AHBENR |= RCC_AHBENR_GPIOFEN;
+    }
+}
+
+void gpio_init_output(GPIO_TypeDef* port, uint8_t pin) {
+    gpio_enable_clock(port);
+
+    /* MODER: 01 = saída */
+    port->MODER &= ~(0x3u << (pin * 2u));
+    port->MODER |=  (0x1u << (pin * 2u));
+
+    /* OTYPER: 0 = push-pull */
+    port->OTYPER &= ~(1u << pin);
+
+    /* OSPEEDR: 11 = alta velocidade */
+    port->OSPEEDR &= ~(0x3u << (pin * 2u));
+    port->OSPEEDR |=  (0x3u << (pin * 2u));
+
+    /* PUPDR: 00 = sem pull */
+    port->PUPDR &= ~(0x3u << (pin * 2u));
+}
+
+void gpio_init_input(GPIO_TypeDef* port, uint8_t pin, bool pull_up, bool pull_down) {
+    gpio_enable_clock(port);
+
+    /* MODER: 00 = entrada */
+    port->MODER &= ~(0x3u << (pin * 2u));
+
+    /* OTYPER: 0 = push-pull */
+    port->OTYPER &= ~(1u << pin);
+
+    /* OSPEEDR: 00 = baixa velocidade */
+    port->OSPEEDR &= ~(0x3u << (pin * 2u));
+
+    /* PUPDR: configura conforme flags (se ambos true, mantém 00) */
+    port->PUPDR &= ~(0x3u << (pin * 2u));
+    if (pull_up && !pull_down) {
+        port->PUPDR |= (0x1u << (pin * 2u));
+    } else if (pull_down && !pull_up) {
+        port->PUPDR |= (0x2u << (pin * 2u));
+    }
+}
+
+void gpio_write(GPIO_TypeDef* port, uint8_t pin, uint8_t level) {
+    if (level) {
+        port->BSRR = (1u << pin);      /* Set */
+    } else {
+        port->BSRR = (1u << (pin + 16u)); /* Reset */
+    }
+}
+
+void gpio_toggle(GPIO_TypeDef* port, uint8_t pin) {
+    port->ODR ^= (1u << pin);
+}
+
+uint8_t gpio_read_input(GPIO_TypeDef* port, uint8_t pin) {
+    return (uint8_t)((port->IDR >> pin) & 0x1u);
+}
+

--- a/stm32_repo/Drivers/gpio.h
+++ b/stm32_repo/Drivers/gpio.h
@@ -1,0 +1,61 @@
+#ifndef GPIO_H
+#define GPIO_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * Estruturas mínimas dos registradores RCC e GPIO
+ * Baseado no RM0091 (STM32F0). Apenas campos utilizados são definidos.
+ */
+
+typedef struct {
+    volatile uint32_t CR;
+    volatile uint32_t CFGR;
+    volatile uint32_t CIR;
+    volatile uint32_t APB2RSTR;
+    volatile uint32_t APB1RSTR;
+    volatile uint32_t AHBENR; /* Offset 0x14 */
+} RCC_TypeDef;
+
+typedef struct {
+    volatile uint32_t MODER;   /* Offset 0x00 */
+    volatile uint32_t OTYPER;  /* Offset 0x04 */
+    volatile uint32_t OSPEEDR; /* Offset 0x08 */
+    volatile uint32_t PUPDR;   /* Offset 0x0C */
+    volatile uint32_t IDR;     /* Offset 0x10 */
+    volatile uint32_t ODR;     /* Offset 0x14 */
+    volatile uint32_t BSRR;    /* Offset 0x18 */
+    volatile uint32_t LCKR;    /* Offset 0x1C */
+    volatile uint32_t AFR[2];  /* Offset 0x20, 0x24 */
+    volatile uint32_t BRR;     /* Offset 0x28 */
+} GPIO_TypeDef;
+
+/*
+ * Ponteiros para bases dos periféricos. No build de testes estes
+ * símbolos podem ser redefinidos para fakes.
+ */
+extern RCC_TypeDef *RCC;
+extern GPIO_TypeDef *GPIOA;
+extern GPIO_TypeDef *GPIOB;
+extern GPIO_TypeDef *GPIOC;
+extern GPIO_TypeDef *GPIOD;
+extern GPIO_TypeDef *GPIOE;
+extern GPIO_TypeDef *GPIOF;
+
+/* Bits de clock no RCC->AHBENR */
+#define RCC_AHBENR_GPIOAEN (1u << 17)
+#define RCC_AHBENR_GPIOBEN (1u << 18)
+#define RCC_AHBENR_GPIOCEN (1u << 19)
+#define RCC_AHBENR_GPIODEN (1u << 20)
+#define RCC_AHBENR_GPIOEEN (1u << 21)
+#define RCC_AHBENR_GPIOFEN (1u << 22)
+
+/* API pública */
+void gpio_init_output(GPIO_TypeDef* port, uint8_t pin);
+void gpio_init_input(GPIO_TypeDef* port, uint8_t pin, bool pull_up, bool pull_down);
+void gpio_write(GPIO_TypeDef* port, uint8_t pin, uint8_t level);
+void gpio_toggle(GPIO_TypeDef* port, uint8_t pin);
+uint8_t gpio_read_input(GPIO_TypeDef* port, uint8_t pin);
+
+#endif /* GPIO_H */


### PR DESCRIPTION
## Summary
- Implement bare‑metal GPIO driver for STM32F0 without HAL
- Add host-side tests exercising GPIO init, write/toggle and read

## Testing
- `cd CMakeHost && mkdir -p build && cd build && cmake ..`
- `cmake --build . --config Release -j`
- `ctest -C Release --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68be250136b08324a44a48e9e01d20ab