### PR TITLE
Add I2C clock enable bits

### DIFF
--- a/stm32_repo/Drivers/rcc.h
+++ b/stm32_repo/Drivers/rcc.h
@@ -47,6 +47,8 @@ typedef struct {
 #define RCC_APB1ENR_TIM3   (1u << 1)
 #define RCC_APB1ENR_SPI2   (1u << 14)
 #define RCC_APB1ENR_USART2 (1u << 17)
+#define RCC_APB1ENR_I2C1   (1u << 21)
+#define RCC_APB1ENR_I2C2   (1u << 22)
 
 /* Predefined system clock configurations */
 enum rcc_sysclk_cfg {


### PR DESCRIPTION
## Summary
- add APB1 enable bits for I2C1 and I2C2 to RCC header

## Testing
- `cd CMakeHost && mkdir -p build && cd build && cmake .. && cmake --build . && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c004263ec48324ad0762b846332872