### PR TITLE
Add Doxygen comments across drivers

### DIFF
--- a/stm32_repo/Drivers/adc.c
+++ b/stm32_repo/Drivers/adc.c
@@ -12,6 +12,12 @@ static void *adc_ctx;
 
 ADC_TypeDef adc1_regs;
 
+/**
+ * @brief Initialize the ADC peripheral with the provided configuration.
+ * @param adc Pointer to the ADC instance.
+ * @param cfg Configuration parameters.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_init(ADC_TypeDef *adc, const adc_cfg_t *cfg) {
     if (!adc || !cfg) {
         return false;
@@ -32,6 +38,13 @@ bool adc_init(ADC_TypeDef *adc, const adc_cfg_t *cfg) {
     return true;
 }
 
+/**
+ * @brief Perform a single conversion using polling.
+ * @param adc     Pointer to the ADC instance.
+ * @param channel Channel to sample.
+ * @param value   Destination for conversion result.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_read_poll(ADC_TypeDef *adc, uint8_t channel, uint16_t *value) {
     if (!adc || !value) {
         return false;
@@ -44,6 +57,14 @@ bool adc_read_poll(ADC_TypeDef *adc, uint8_t channel, uint16_t *value) {
     return true;
 }
 
+/**
+ * @brief Start a conversion and notify via interrupt callback.
+ * @param adc     Pointer to the ADC instance.
+ * @param channel Channel to sample.
+ * @param cb      Callback invoked when conversion completes.
+ * @param ctx     User context passed to callback.
+ * @return true on success, false otherwise.
+ */
 bool adc_start_it(ADC_TypeDef *adc, uint8_t channel, adc_cb_t cb, void *ctx) {
     if (!adc || !cb) {
         return false;
@@ -57,6 +78,15 @@ bool adc_start_it(ADC_TypeDef *adc, uint8_t channel, adc_cb_t cb, void *ctx) {
     return true;
 }
 
+/**
+ * @brief Start a DMA transfer for repeated conversions.
+ * @param adc     Pointer to the ADC instance.
+ * @param dma_ch  DMA channel used for transfers.
+ * @param channel Channel to sample.
+ * @param buf     Buffer to fill with samples.
+ * @param len     Number of samples to capture.
+ * @return true on success, false otherwise.
+ */
 bool adc_start_dma(ADC_TypeDef *adc, DMA_Channel_TypeDef *dma_ch, uint8_t channel,
                    uint16_t *buf, size_t len) {
     if (!adc || !dma_ch || !buf || len == 0u) {
@@ -72,6 +102,7 @@ bool adc_start_dma(ADC_TypeDef *adc, DMA_Channel_TypeDef *dma_ch, uint8_t channe
     return true;
 }
 
+/** ADC interrupt handler for conversion completion. */
 void ADC1_IRQHandler(void) {
     if ((ADC1->ISR & ADC_ISR_EOC) && adc_cb) {
         uint16_t val = (uint16_t)ADC1->DR;
@@ -81,11 +112,13 @@ void ADC1_IRQHandler(void) {
 }
 
 /* Example functions demonstrating usage */
+/** Dummy callback used in usage examples. */
 static void adc_dummy_cb(void *ctx, uint16_t v) {
     (void)ctx;
     (void)v;
 }
 
+/** Example: polling conversion triggered by software. */
 void adc_example_poll_sw(void) {
     adc_cfg_t cfg = {
         .resolution = ADC_RES_12BIT,
@@ -98,6 +131,7 @@ void adc_example_poll_sw(void) {
     adc_read_poll(ADC1, 5u, &value);
 }
 
+/** Example: polling conversion triggered by hardware. */
 void adc_example_poll_hw(void) {
     adc_cfg_t cfg = {
         .resolution = ADC_RES_12BIT,
@@ -110,6 +144,7 @@ void adc_example_poll_hw(void) {
     adc_read_poll(ADC1, 3u, &value);
 }
 
+/** Example: interrupt conversion triggered by software. */
 void adc_example_it_sw(void) {
     adc_cfg_t cfg = {
         .resolution = ADC_RES_8BIT,
@@ -121,6 +156,7 @@ void adc_example_it_sw(void) {
     adc_start_it(ADC1, 0u, adc_dummy_cb, NULL);
 }
 
+/** Example: interrupt conversion triggered by hardware. */
 void adc_example_it_hw(void) {
     adc_cfg_t cfg = {
         .resolution = ADC_RES_10BIT,
@@ -132,6 +168,7 @@ void adc_example_it_hw(void) {
     adc_start_it(ADC1, 1u, adc_dummy_cb, NULL);
 }
 
+/** Example: DMA conversion triggered by software. */
 void adc_example_dma_sw(void) {
     uint16_t buffer[8];
     adc_cfg_t cfg = {
@@ -145,6 +182,7 @@ void adc_example_dma_sw(void) {
     adc_start_dma(ADC1, &ch, 2u, buffer, 8u);
 }
 
+/** Example: DMA conversion triggered by hardware. */
 void adc_example_dma_hw(void) {
     uint16_t buffer[4];
     adc_cfg_t cfg = {

--- a/stm32_repo/Drivers/adc.h
+++ b/stm32_repo/Drivers/adc.h
@@ -19,7 +19,12 @@ typedef struct {
 } ADC_TypeDef;
 
 #define ADC1_BASE 0x40012400u
+#ifdef STM32F0_FIRMWARE
 #define ADC1 ((ADC_TypeDef *)ADC1_BASE)
+#else
+extern ADC_TypeDef adc1_regs;
+#define ADC1 (&adc1_regs)
+#endif
 
 /* ADC interrupt flags */
 #define ADC_ISR_ADRDY (1u << 0)
@@ -84,22 +89,62 @@ typedef struct {
     enum adc_trigger_edge trigger_edge;
 } adc_cfg_t;
 
+/** Callback type for ADC conversion completion. */
 typedef void (*adc_cb_t)(void *ctx, uint16_t value);
 
+/**
+ * @brief Initialize an ADC peripheral.
+ * @param adc  Pointer to ADC instance.
+ * @param cfg  Configuration parameters.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_init(ADC_TypeDef *adc, const adc_cfg_t *cfg);
+
+/**
+ * @brief Perform a polling conversion on a channel.
+ * @param adc     Pointer to ADC instance.
+ * @param channel Channel number to sample.
+ * @param value   Output pointer for the conversion result.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_read_poll(ADC_TypeDef *adc, uint8_t channel, uint16_t *value);
+
+/**
+ * @brief Start an interrupt-driven conversion.
+ * @param adc     Pointer to ADC instance.
+ * @param channel Channel number to sample.
+ * @param cb      Completion callback.
+ * @param ctx     User context passed to callback.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_start_it(ADC_TypeDef *adc, uint8_t channel, adc_cb_t cb, void *ctx);
+
+/**
+ * @brief Start a DMA-based conversion sequence.
+ * @param adc     Pointer to ADC instance.
+ * @param dma_ch  DMA channel used for transfers.
+ * @param channel Channel number to sample.
+ * @param buf     Destination buffer.
+ * @param len     Number of samples to capture.
+ * @return true on success, false on invalid arguments.
+ */
 bool adc_start_dma(ADC_TypeDef *adc, DMA_Channel_TypeDef *dma_ch, uint8_t channel,
                    uint16_t *buf, size_t len);
 
+/** ADC interrupt handler for ADC1. */
 void ADC1_IRQHandler(void);
 
-/* Usage examples (for reference only) */
+/** Example: polling conversion triggered by software. */
 void adc_example_poll_sw(void);
+/** Example: polling conversion triggered by hardware. */
 void adc_example_poll_hw(void);
+/** Example: interrupt-driven conversion triggered by software. */
 void adc_example_it_sw(void);
+/** Example: interrupt-driven conversion triggered by hardware. */
 void adc_example_it_hw(void);
+/** Example: DMA conversion triggered by software. */
 void adc_example_dma_sw(void);
+/** Example: DMA conversion triggered by hardware. */
 void adc_example_dma_hw(void);
 
 #endif /* ADC_H */

--- a/stm32_repo/Drivers/cm0.c
+++ b/stm32_repo/Drivers/cm0.c
@@ -19,30 +19,43 @@
 #define SYST_CSR_TICKINT   (1u << 1)
 #define SYST_CSR_CLKSOURCE (1u << 2)
 
+/** Enable global interrupts. */
 void cm0_enable_irq_global(void) { __asm volatile ("cpsie i"); }
+/** Disable global interrupts. */
 void cm0_disable_irq_global(void) { __asm volatile ("cpsid i"); }
+/** Enter wait-for-interrupt state. */
 void cm0_wfi(void) { __asm volatile ("wfi"); }
 
+/** Enable an IRQ in the NVIC. */
 void cm0_nvic_enable(IRQn_Type irq) {
     NVIC_ISER = (uint32_t)1u << ((uint32_t)irq & 0x1Fu);
 }
 
+/** Disable an IRQ in the NVIC. */
 void cm0_nvic_disable(IRQn_Type irq) {
     NVIC_ICER = (uint32_t)1u << ((uint32_t)irq & 0x1Fu);
 }
 
+/** Set an IRQ as pending. */
 void cm0_nvic_set_pending(IRQn_Type irq) {
     NVIC_ISPR = (uint32_t)1u << ((uint32_t)irq & 0x1Fu);
 }
 
+/** Clear the pending flag of an IRQ. */
 void cm0_nvic_clear_pending(IRQn_Type irq) {
     NVIC_ICPR = (uint32_t)1u << ((uint32_t)irq & 0x1Fu);
 }
 
+/** Set priority for an IRQ (0=highest, 3=lowest). */
 void cm0_nvic_set_priority(IRQn_Type irq, uint8_t prio) {
     NVIC_IPR[(uint32_t)irq & 0x1Fu] = (uint8_t)((prio & 0x3u) << 6);
 }
 
+/**
+ * @brief Configure the SysTick timer.
+ * @param ticks Reload value for the timer.
+ * @return true on success, false if ticks is out of range.
+ */
 bool cm0_systick_config(uint32_t ticks) {
     if (ticks == 0u || ticks > 0xFFFFFFu) {
         return false;

--- a/stm32_repo/Drivers/cm0.h
+++ b/stm32_repo/Drivers/cm0.h
@@ -7,15 +7,24 @@
 
 #include "irqn.h"
 
+/** Enable global interrupts. */
 void cm0_enable_irq_global(void);
+/** Disable global interrupts. */
 void cm0_disable_irq_global(void);
+/** Enter low-power wait-for-interrupt state. */
 void cm0_wfi(void);
 
+/** Enable a specific IRQ in the NVIC. */
 void cm0_nvic_enable(IRQn_Type irq);
+/** Disable a specific IRQ in the NVIC. */
 void cm0_nvic_disable(IRQn_Type irq);
+/** Set a pending flag for an IRQ. */
 void cm0_nvic_set_pending(IRQn_Type irq);
+/** Clear the pending flag of an IRQ. */
 void cm0_nvic_clear_pending(IRQn_Type irq);
-void cm0_nvic_set_priority(IRQn_Type irq, uint8_t prio); /* 0=highest, 3=lowest */
+/** Set priority for an IRQ (0=highest, 3=lowest). */
+void cm0_nvic_set_priority(IRQn_Type irq, uint8_t prio);
+/** Configure the SysTick timer with the provided tick count. */
 bool cm0_systick_config(uint32_t ticks);
 
 /* Example usage:

--- a/stm32_repo/Drivers/cm0_stub.c
+++ b/stm32_repo/Drivers/cm0_stub.c
@@ -2,16 +2,23 @@
 
 /* Empty implementations for host testing environment. */
 
-#if 0
+/** Stub: enable global interrupts. */
 void cm0_enable_irq_global(void) {}
+/** Stub: disable global interrupts. */
 void cm0_disable_irq_global(void) {}
+/** Stub: wait for interrupt. */
 void cm0_wfi(void) {}
 
+/** Stub: enable NVIC interrupt. */
 void cm0_nvic_enable(IRQn_Type irq) { (void)irq; }
+/** Stub: disable NVIC interrupt. */
 void cm0_nvic_disable(IRQn_Type irq) { (void)irq; }
+/** Stub: set pending IRQ. */
 void cm0_nvic_set_pending(IRQn_Type irq) { (void)irq; }
+/** Stub: clear pending IRQ. */
 void cm0_nvic_clear_pending(IRQn_Type irq) { (void)irq; }
+/** Stub: set interrupt priority. */
 void cm0_nvic_set_priority(IRQn_Type irq, uint8_t prio) { (void)irq; (void)prio; }
 
+/** Stub: configure SysTick timer. */
 bool cm0_systick_config(uint32_t ticks) { (void)ticks; return true; }
-#endif

--- a/stm32_repo/Drivers/dma.c
+++ b/stm32_repo/Drivers/dma.c
@@ -4,28 +4,34 @@
 typedef struct { dma_cb_t cb; void *ctx; } dma_cb_entry_t;
 static dma_cb_entry_t dma_callbacks[7];
 
+/** Configure a DMA channel control register. */
 bool dma_config_channel(DMA_Channel_TypeDef *ch, uint32_t ccr) {
     if (!ch) return false;
     ch->CCR = ccr;
     return true;
 }
 
+/** Set the peripheral address for a channel. */
 void dma_set_peripheral(DMA_Channel_TypeDef *ch, const void *addr) {
     ch->CPAR = (uint32_t)(uintptr_t)addr;
 }
 
+/** Set the memory address for a channel. */
 void dma_set_memory(DMA_Channel_TypeDef *ch, void *addr) {
     ch->CMAR = (uint32_t)(uintptr_t)addr;
 }
 
+/** Set the transfer count for a channel. */
 void dma_set_count(DMA_Channel_TypeDef *ch, uint16_t count) {
     ch->CNDTR = count;
 }
 
+/** Enable or disable a DMA channel. */
 void dma_enable(DMA_Channel_TypeDef *ch, bool en) {
     if (en) ch->CCR |= DMA_CCR_EN; else ch->CCR &= ~DMA_CCR_EN;
 }
 
+/** Register a callback for a DMA channel. */
 void dma_set_callback(DMA_TypeDef *dma, uint8_t ch_idx, dma_cb_t cb, void *ctx) {
     if (!dma || ch_idx == 0u || ch_idx > 7u) return;
     dma_callbacks[ch_idx - 1u].cb = cb;
@@ -38,11 +44,13 @@ void dma_set_callback(DMA_TypeDef *dma, uint8_t ch_idx, dma_cb_t cb, void *ctx) 
     }
 }
 
+/** Get interrupt status flags for a channel. */
 uint32_t dma_get_isr(DMA_TypeDef *dma, uint8_t ch_idx) {
     uint32_t shift = (ch_idx - 1u) * 4u;
     return (dma->ISR >> shift) & 0xFu;
 }
 
+/** Clear interrupt flags for a channel. */
 void dma_clear_isr(DMA_TypeDef *dma, uint8_t ch_idx, uint32_t flags) {
     uint32_t shift = (ch_idx - 1u) * 4u;
     uint32_t mask = 0u;
@@ -52,6 +60,7 @@ void dma_clear_isr(DMA_TypeDef *dma, uint8_t ch_idx, uint32_t flags) {
     dma->IFCR = mask;
 }
 
+/** Dispatch interrupt to registered callback. */
 static void dma_dispatch(uint8_t ch_idx) {
     dma_cb_entry_t *e = &dma_callbacks[ch_idx - 1u];
     if (e->cb) {
@@ -65,8 +74,12 @@ static void dma_dispatch(uint8_t ch_idx) {
     }
 }
 
+/** DMA1 channel 1 interrupt handler. */
 void DMA1_Channel1_IRQHandler(void) { dma_dispatch(1u); }
+/** DMA1 channel 2 and 3 interrupt handler. */
 void DMA1_Channel2_3_IRQHandler(void) { dma_dispatch(2u); dma_dispatch(3u); }
+/** DMA1 channel 4 and 5 interrupt handler. */
 void DMA1_Channel4_5_IRQHandler(void) { dma_dispatch(4u); dma_dispatch(5u); }
+/** DMA1 channel 6 and 7 interrupt handler. */
 void DMA1_Channel6_7_IRQHandler(void) { dma_dispatch(6u); dma_dispatch(7u); }
 

--- a/stm32_repo/Drivers/dma.h
+++ b/stm32_repo/Drivers/dma.h
@@ -39,15 +39,68 @@ typedef struct {
 #define DMA_IRQ_HT 0x2u
 #define DMA_IRQ_TE 0x4u
 
+/** Callback type for DMA transfer events. */
 typedef void (*dma_cb_t)(void *ctx, uint32_t flags);
 
+/**
+ * @brief Configure a DMA channel control register.
+ * @param ch  DMA channel instance.
+ * @param ccr Value for the CCR register.
+ * @return true on success, false on invalid arguments.
+ */
 bool dma_config_channel(DMA_Channel_TypeDef *ch, uint32_t ccr);
+
+/**
+ * @brief Set the peripheral address for a channel.
+ * @param ch   DMA channel instance.
+ * @param addr Peripheral source/destination address.
+ */
 void dma_set_peripheral(DMA_Channel_TypeDef *ch, const void *addr);
+
+/**
+ * @brief Set the memory address for a channel.
+ * @param ch   DMA channel instance.
+ * @param addr Memory source/destination address.
+ */
 void dma_set_memory(DMA_Channel_TypeDef *ch, void *addr);
+
+/**
+ * @brief Configure the number of transfers for a channel.
+ * @param ch    DMA channel instance.
+ * @param count Number of items to transfer.
+ */
 void dma_set_count(DMA_Channel_TypeDef *ch, uint16_t count);
+
+/**
+ * @brief Enable or disable a DMA channel.
+ * @param ch DMA channel instance.
+ * @param en true to enable, false to disable.
+ */
 void dma_enable(DMA_Channel_TypeDef *ch, bool en);
+
+/**
+ * @brief Register a callback for a DMA channel.
+ * @param dma     DMA controller instance.
+ * @param ch_idx  Channel index (1..7).
+ * @param cb      Callback function.
+ * @param ctx     User context passed to callback.
+ */
 void dma_set_callback(DMA_TypeDef *dma, uint8_t ch_idx, dma_cb_t cb, void *ctx);
+
+/**
+ * @brief Read interrupt status for a channel.
+ * @param dma    DMA controller instance.
+ * @param ch_idx Channel index.
+ * @return Flags for the specified channel.
+ */
 uint32_t dma_get_isr(DMA_TypeDef *dma, uint8_t ch_idx);
+
+/**
+ * @brief Clear interrupt flags for a channel.
+ * @param dma    DMA controller instance.
+ * @param ch_idx Channel index.
+ * @param flags  Flags to clear.
+ */
 void dma_clear_isr(DMA_TypeDef *dma, uint8_t ch_idx, uint32_t flags);
 
 #endif /* DMA_H */

--- a/stm32_repo/Drivers/gpio.h
+++ b/stm32_repo/Drivers/gpio.h
@@ -55,21 +55,74 @@ typedef struct {
     uint8_t alternate; /* alternate function index when mode == GPIO_MODE_AF */
 } gpio_cfg_t;
 
+/** Callback type for GPIO interrupts. */
 typedef void (*gpio_cb_t)(void *ctx, uint8_t pin);
+
+/**
+ * @brief Configure a GPIO pin with the specified settings.
+ * @param port GPIO port base.
+ * @param pin  Pin number (0-15).
+ * @param cfg  Configuration structure.
+ */
 void gpio_config(GPIO_TypeDef *port, uint8_t pin, const gpio_cfg_t *cfg);
+
+/**
+ * @brief Reset a GPIO pin to default state.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ */
 void gpio_deinit(GPIO_TypeDef *port, uint8_t pin);
+
+/**
+ * @brief Write logic level to an output pin.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ * @param level 0 for low, non-zero for high.
+ */
 void gpio_write(GPIO_TypeDef *port, uint8_t pin, uint8_t level);
+
+/**
+ * @brief Toggle the state of an output pin.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ */
 void gpio_toggle(GPIO_TypeDef *port, uint8_t pin);
+
+/**
+ * @brief Read the current level of a pin.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ * @return Pin logic level.
+ */
 uint8_t gpio_read(GPIO_TypeDef *port, uint8_t pin);
 
+/**
+ * @brief Attach an interrupt to a GPIO pin.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ * @param edge Trigger edge selection.
+ * @param cb   Callback invoked on interrupt.
+ * @param ctx  User context passed to callback.
+ * @return true on success, false on invalid arguments.
+ */
 bool gpio_attach_irq(GPIO_TypeDef *port, uint8_t pin, enum gpio_edge_t edge,
                      gpio_cb_t cb, void *ctx);
+
+/**
+ * @brief Detach any interrupt from a GPIO pin.
+ * @param port GPIO port base.
+ * @param pin  Pin number.
+ */
 void gpio_detach_irq(GPIO_TypeDef *port, uint8_t pin);
 
 /* Convenience examples to exercise the driver from main() */
+/** Example: configure and drive output pins. */
 void gpio_example_output(void);
+/** Example: configure a pin as input. */
 void gpio_example_input(void);
+/** Example: attach an interrupt to a pin. */
 void gpio_example_irq(void);
+/** Example: toggle a pin. */
 void gpio_example_toggle(void);
 
 /* Example usage:

--- a/stm32_repo/Drivers/i2c.h
+++ b/stm32_repo/Drivers/i2c.h
@@ -23,25 +23,40 @@ typedef struct {
     uint16_t own_address;
 } i2c_cfg_t;
 
+/** Callback type for asynchronous I2C operations. */
 typedef void (*i2c_cb_t)(void *ctx);
 
+/** Initialize an I2C peripheral. */
 bool i2c_init(I2C_TypeDef *i2c, const i2c_cfg_t *cfg);
+/** Enable or disable an I2C peripheral. */
 void i2c_enable(I2C_TypeDef *i2c, bool en);
 
+/** Perform a blocking write transaction. */
 bool i2c_write_poll(I2C_TypeDef *i2c, uint8_t addr, const uint8_t *data, size_t len);
+/** Perform a blocking read transaction. */
 bool i2c_read_poll(I2C_TypeDef *i2c, uint8_t addr, uint8_t *data, size_t len);
 
+/** Start an interrupt-driven write transaction. */
 bool i2c_write_it_start(I2C_TypeDef *i2c, uint8_t addr, const uint8_t *data, size_t len, i2c_cb_t cb, void *ctx);
+/** Start an interrupt-driven read transaction. */
 bool i2c_read_it_start(I2C_TypeDef *i2c, uint8_t addr, uint8_t *data, size_t len, i2c_cb_t cb, void *ctx);
 
+/** Start a DMA write transaction. */
 bool i2c_write_dma_start(I2C_TypeDef *i2c, DMA_Channel_TypeDef *tx_ch, uint8_t addr, const uint8_t *data, size_t len, i2c_cb_t cb, void *ctx);
+/** Start a DMA read transaction. */
 bool i2c_read_dma_start(I2C_TypeDef *i2c, DMA_Channel_TypeDef *rx_ch, uint8_t addr, uint8_t *data, size_t len, i2c_cb_t cb, void *ctx);
 
+/** Example: polling write transaction. */
 void i2c_example_write_poll(void);
+/** Example: polling read transaction. */
 void i2c_example_read_poll(void);
+/** Example: interrupt-driven write transaction. */
 void i2c_example_write_it(void);
+/** Example: interrupt-driven read transaction. */
 void i2c_example_read_it(void);
+/** Example: DMA write transaction. */
 void i2c_example_write_dma(void);
+/** Example: DMA read transaction. */
 void i2c_example_read_dma(void);
 
 #endif /* I2C_H */

--- a/stm32_repo/Drivers/rcc.c
+++ b/stm32_repo/Drivers/rcc.c
@@ -7,6 +7,7 @@ FLASH_TypeDef flash_regs;
 
 static uint32_t sysclk_hz = 8000000u;
 
+/** Configure flash latency based on system clock. */
 static void flash_latency_cfg(uint32_t hz) {
     if (hz > 24000000u) {
         FLASH->ACR = 1u; /* 1 wait state */
@@ -15,6 +16,7 @@ static void flash_latency_cfg(uint32_t hz) {
     }
 }
 
+/** Configure system clock using predefined settings. */
 bool rcc_sysclk_config(enum rcc_sysclk_cfg cfg) {
     switch (cfg) {
     case RCC_SYSCLK_HSI8:
@@ -90,6 +92,12 @@ bool rcc_sysclk_config(enum rcc_sysclk_cfg cfg) {
     }
 }
 
+/**
+ * @brief Configure system clock from external oscillator.
+ * @param hse_hz Frequency of external crystal.
+ * @param desired_sysclk Desired system clock frequency.
+ * @return true on success, false on invalid parameters.
+ */
 bool rcc_sysclk_config_hse(uint32_t hse_hz, uint32_t desired_sysclk) {
     if (hse_hz == 0u || desired_sysclk == 0u) {
         return false;
@@ -124,27 +132,32 @@ bool rcc_sysclk_config_hse(uint32_t hse_hz, uint32_t desired_sysclk) {
     return true;
 }
 
+/** Get current system clock frequency. */
 uint32_t rcc_sysclk_hz(void) {
     return sysclk_hz;
 }
 
+/** Retrieve current flash wait state configuration. */
 uint32_t rcc_flash_latency_ws(void) {
     return FLASH->ACR & 0x7u;
 }
 
+/** Enable AHB peripheral clocks. */
 void rcc_ahb_enable(uint32_t mask) {
     RCC->AHBENR |= mask;
 }
 
+/** Enable APB1 peripheral clocks. */
 void rcc_apb1_enable(uint32_t mask) {
     RCC->APB1ENR |= mask;
 }
 
+/** Enable APB2 peripheral clocks. */
 void rcc_apb2_enable(uint32_t mask) {
     RCC->APB2ENR |= mask;
 }
 
+/** Route system clock to MCO pin without prescaler. */
 void rcc_mco_enable_sysclk(void) {
-    /* route system clock to MCO pin without prescaler */
     RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_MCO_MASK) | RCC_CFGR_MCO_SYSCLK;
 }

--- a/stm32_repo/Drivers/rcc.h
+++ b/stm32_repo/Drivers/rcc.h
@@ -85,15 +85,23 @@ enum rcc_sysclk_cfg {
 #define RCC_CFGR_MCO_MASK    (7u << RCC_CFGR_MCO_SHIFT)
 #define RCC_CFGR_MCO_SYSCLK  (4u << RCC_CFGR_MCO_SHIFT)
 
+/** Configure system clock using predefined configuration. */
 bool rcc_sysclk_config(enum rcc_sysclk_cfg cfg);
+/** Configure system clock based on external HSE frequency. */
 bool rcc_sysclk_config_hse(uint32_t hse_hz, uint32_t sysclk_hz);
+/** Get current system clock frequency. */
 uint32_t rcc_sysclk_hz(void);
+/** Get flash latency wait states. */
 uint32_t rcc_flash_latency_ws(void);
 
+/** Enable AHB peripheral clocks using mask. */
 void rcc_ahb_enable(uint32_t mask);
+/** Enable APB1 peripheral clocks using mask. */
 void rcc_apb1_enable(uint32_t mask);
+/** Enable APB2 peripheral clocks using mask. */
 void rcc_apb2_enable(uint32_t mask);
 
+/** Output system clock on MCO pin. */
 void rcc_mco_enable_sysclk(void);
 
 #endif /* RCC_H */

--- a/stm32_repo/Drivers/rtc.c
+++ b/stm32_repo/Drivers/rtc.c
@@ -9,6 +9,7 @@ struct RTC_TypeDef {
     volatile uint32_t WUTR;
 };
 
+/** Initialize RTC peripheral. */
 bool rtc_init(RTC_TypeDef *rtc) {
     if (!rtc) {
         return false;
@@ -18,6 +19,7 @@ bool rtc_init(RTC_TypeDef *rtc) {
     return true;
 }
 
+/** Set date and time registers. */
 bool rtc_set_datetime(RTC_TypeDef *rtc, const rtc_datetime_t *dt) {
     if (!rtc || !dt) {
         return false;
@@ -32,6 +34,7 @@ bool rtc_set_datetime(RTC_TypeDef *rtc, const rtc_datetime_t *dt) {
     return true;
 }
 
+/** Retrieve date and time from registers. */
 bool rtc_get_datetime(RTC_TypeDef *rtc, rtc_datetime_t *dt) {
     if (!rtc || !dt) {
         return false;
@@ -47,6 +50,7 @@ bool rtc_get_datetime(RTC_TypeDef *rtc, rtc_datetime_t *dt) {
     return true;
 }
 
+/** Configure wakeup timer. */
 bool rtc_set_wakeup(RTC_TypeDef *rtc, uint16_t seconds) {
     if (!rtc || seconds == 0u) {
         return false;
@@ -56,6 +60,7 @@ bool rtc_set_wakeup(RTC_TypeDef *rtc, uint16_t seconds) {
     return true;
 }
 
+/** Disable wakeup timer. */
 void rtc_disable_wakeup(RTC_TypeDef *rtc) {
     if (!rtc) {
         return;
@@ -63,6 +68,7 @@ void rtc_disable_wakeup(RTC_TypeDef *rtc) {
     rtc->CR &= ~1u;
 }
 
+/** Example: initialize RTC and set date/time. */
 void rtc_example_basic(void) {
     rtc_datetime_t dt = {
         .year = 2024,
@@ -76,6 +82,7 @@ void rtc_example_basic(void) {
     rtc_set_datetime(RTC, &dt);
 }
 
+/** Example: configure periodic wakeup. */
 void rtc_example_wakeup(void) {
     rtc_init(RTC);
     rtc_set_wakeup(RTC, 5u);

--- a/stm32_repo/Drivers/rtc.h
+++ b/stm32_repo/Drivers/rtc.h
@@ -19,13 +19,20 @@ typedef struct {
     uint8_t seconds;
 } rtc_datetime_t;
 
+/** Initialize RTC peripheral. */
 bool rtc_init(RTC_TypeDef *rtc);
+/** Set current date and time. */
 bool rtc_set_datetime(RTC_TypeDef *rtc, const rtc_datetime_t *dt);
+/** Retrieve current date and time. */
 bool rtc_get_datetime(RTC_TypeDef *rtc, rtc_datetime_t *dt);
+/** Configure wakeup timer in seconds. */
 bool rtc_set_wakeup(RTC_TypeDef *rtc, uint16_t seconds);
+/** Disable wakeup timer. */
 void rtc_disable_wakeup(RTC_TypeDef *rtc);
 
+/** Example: basic RTC initialization and set time. */
 void rtc_example_basic(void);
+/** Example: configure periodic wakeup. */
 void rtc_example_wakeup(void);
 
 /* Example usage:

--- a/stm32_repo/Drivers/spi.h
+++ b/stm32_repo/Drivers/spi.h
@@ -55,7 +55,6 @@ enum spi_nss_t {
 #define SPI_ERROR_UDR   0x4u
 #define SPI_ERROR_CRC   0x8u
 
-typedef void (*spi_cb_t)(void *ctx, uint32_t sr);
 
 typedef struct {
     enum spi_mode_t mode;
@@ -69,23 +68,41 @@ typedef struct {
     uint16_t crc_poly;
 } spi_cfg_t;
 
-bool spi_init(SPI_TypeDef *spi, const spi_cfg_t *cfg);
-void spi_enable(SPI_TypeDef *spi, bool enable);
-uint16_t spi_transfer(SPI_TypeDef *spi, uint16_t data);
-void spi_enable_irq(SPI_TypeDef *spi, uint32_t mask);
-bool spi_attach_irq(SPI_TypeDef *spi, spi_cb_t cb, void *ctx);
-void spi_detach_irq(SPI_TypeDef *spi);
-void spi_enable_dma(SPI_TypeDef *spi, bool rx, bool tx);
-uint32_t spi_get_error(SPI_TypeDef *spi);
-void spi_clear_error(SPI_TypeDef *spi, uint32_t errors);
-void spi_cs_init(GPIO_TypeDef *port, uint8_t pin);
-void spi_cs_select(GPIO_TypeDef *port, uint8_t pin, bool select);
-
-typedef void (*spi_xfer_cb_t)(void *ctx);
-bool spi_transfer_it_start(SPI_TypeDef *spi, const uint16_t *tx, uint16_t *rx, size_t len, spi_xfer_cb_t cb, void *ctx);
-bool spi_transfer_dma_start(SPI_TypeDef *spi, DMA_Channel_TypeDef *tx_ch, DMA_Channel_TypeDef *rx_ch, const uint16_t *tx, uint16_t *rx, size_t len, spi_xfer_cb_t cb, void *ctx);
-
-void spi_example_jedec_id(void);
-void spi_example_display_stream(const uint8_t *data, size_t len);
+/** Callback type for SPI interrupts. */
+typedef void (*spi_cb_t)(void *ctx, uint32_t sr);
 
 #endif /* SPI_H */
+/** Initialize an SPI peripheral. */
+bool spi_init(SPI_TypeDef *spi, const spi_cfg_t *cfg);
+/** Enable or disable SPI. */
+void spi_enable(SPI_TypeDef *spi, bool enable);
+/** Transfer a word over SPI in polling mode. */
+uint16_t spi_transfer(SPI_TypeDef *spi, uint16_t data);
+/** Enable specific SPI interrupts. */
+void spi_enable_irq(SPI_TypeDef *spi, uint32_t mask);
+/** Register an SPI interrupt callback. */
+bool spi_attach_irq(SPI_TypeDef *spi, spi_cb_t cb, void *ctx);
+/** Detach SPI interrupt callback. */
+void spi_detach_irq(SPI_TypeDef *spi);
+/** Enable or disable DMA for SPI. */
+void spi_enable_dma(SPI_TypeDef *spi, bool rx, bool tx);
+/** Retrieve error flags from SPI. */
+uint32_t spi_get_error(SPI_TypeDef *spi);
+/** Clear specific SPI error flags. */
+void spi_clear_error(SPI_TypeDef *spi, uint32_t errors);
+/** Initialize a GPIO pin as chip-select. */
+void spi_cs_init(GPIO_TypeDef *port, uint8_t pin);
+/** Control the chip-select pin. */
+void spi_cs_select(GPIO_TypeDef *port, uint8_t pin, bool select);
+
+/** Callback type for asynchronous SPI transfers. */
+typedef void (*spi_xfer_cb_t)(void *ctx);
+/** Start interrupt-driven SPI transfer. */
+bool spi_transfer_it_start(SPI_TypeDef *spi, const uint16_t *tx, uint16_t *rx, size_t len, spi_xfer_cb_t cb, void *ctx);
+/** Start DMA-driven SPI transfer. */
+bool spi_transfer_dma_start(SPI_TypeDef *spi, DMA_Channel_TypeDef *tx_ch, DMA_Channel_TypeDef *rx_ch, const uint16_t *tx, uint16_t *rx, size_t len, spi_xfer_cb_t cb, void *ctx);
+
+/** Example: read JEDEC ID from SPI flash. */
+void spi_example_jedec_id(void);
+/** Example: stream data to SPI peripheral. */
+void spi_example_display_stream(const uint8_t *data, size_t len);

--- a/stm32_repo/Drivers/tim.c
+++ b/stm32_repo/Drivers/tim.c
@@ -36,6 +36,7 @@ typedef struct { tim_cb_t cb; void *ctx; } tim_cb_entry_t;
 static tim_cb_entry_t tim_update_cb[7];
 static tim_cb_entry_t tim_cc_cb[7][4];
 
+/** Map timer pointer to index for callback arrays. */
 static uint8_t tim_index(TIM_TypeDef *tim) {
     if (tim == TIM1) return 0u;
     if (tim == TIM2) return 1u;
@@ -47,6 +48,7 @@ static uint8_t tim_index(TIM_TypeDef *tim) {
     return 0xFFu;
 }
 
+/** Determine NVIC IRQ number for a timer. */
 static IRQn_Type tim_irqn(TIM_TypeDef *tim) {
     if (tim == TIM1) return TIM1_BRK_UP_TRG_COM_IRQn;
     if (tim == TIM2) return TIM2_IRQn;
@@ -58,6 +60,7 @@ static IRQn_Type tim_irqn(TIM_TypeDef *tim) {
     return (IRQn_Type)0;
 }
 
+/** Enable RCC clock for the given timer. */
 static bool tim_rcc_enable(TIM_TypeDef *tim) {
     if (tim == TIM1) { rcc_apb2_enable(RCC_APB2ENR_TIM1); return true; }
     if (tim == TIM2) { rcc_apb1_enable(RCC_APB1ENR_TIM2); return true; }
@@ -69,6 +72,7 @@ static bool tim_rcc_enable(TIM_TypeDef *tim) {
     return false;
 }
 
+/** Initialize timer with basic configuration. */
 bool tim_init(TIM_TypeDef *tim, const tim_cfg_t *cfg) {
     if (!tim || !cfg) return false;
     if (!tim_rcc_enable(tim)) return false;
@@ -82,15 +86,18 @@ bool tim_init(TIM_TypeDef *tim, const tim_cfg_t *cfg) {
     return true;
 }
 
+/** Enable or disable timer counting. */
 void tim_enable(TIM_TypeDef *tim, bool en) {
     if (!tim) return;
     if (en) tim->CR1 |= TIM_CR1_CEN; else tim->CR1 &= ~TIM_CR1_CEN;
 }
 
+/** Return pointer to CCR register for a channel. */
 static volatile uint32_t *tim_ccr(TIM_TypeDef *tim, uint8_t ch) {
     return &(&tim->CCR1)[ch - 1u];
 }
 
+/** Configure an output compare channel. */
 bool tim_config_output(TIM_TypeDef *tim, uint8_t ch, const tim_oc_cfg_t *cfg) {
     if (!tim || !cfg || ch == 0u || ch > 4u) return false;
     volatile uint32_t *ccmr = (ch <= 2u) ? &tim->CCMR1 : &tim->CCMR2;
@@ -103,11 +110,13 @@ bool tim_config_output(TIM_TypeDef *tim, uint8_t ch, const tim_oc_cfg_t *cfg) {
     return true;
 }
 
+/** Update compare value of a channel. */
 void tim_set_compare(TIM_TypeDef *tim, uint8_t ch, uint32_t compare) {
     if (!tim || ch == 0u || ch > 4u) return;
     *tim_ccr(tim, ch) = compare;
 }
 
+/** Configure an input capture channel. */
 bool tim_config_input(TIM_TypeDef *tim, uint8_t ch, const tim_ic_cfg_t *cfg) {
     if (!tim || !cfg || ch == 0u || ch > 4u) return false;
     volatile uint32_t *ccmr = (ch <= 2u) ? &tim->CCMR1 : &tim->CCMR2;
@@ -126,16 +135,19 @@ bool tim_config_input(TIM_TypeDef *tim, uint8_t ch, const tim_ic_cfg_t *cfg) {
     return true;
 }
 
+/** Read captured value. */
 uint32_t tim_get_capture(TIM_TypeDef *tim, uint8_t ch) {
     if (!tim || ch == 0u || ch > 4u) return 0u;
     return *tim_ccr(tim, ch);
 }
 
+/** Enable or disable DMA requests. */
 void tim_enable_dma(TIM_TypeDef *tim, uint32_t mask, bool en) {
     if (!tim) return;
     if (en) tim->DIER |= mask; else tim->DIER &= ~mask;
 }
 
+/** Register callback for update events. */
 void tim_attach_update_irq(TIM_TypeDef *tim, tim_cb_t cb, void *ctx) {
     uint8_t idx = tim_index(tim);
     if (idx == 0xFFu) return;
@@ -149,6 +161,7 @@ void tim_attach_update_irq(TIM_TypeDef *tim, tim_cb_t cb, void *ctx) {
     }
 }
 
+/** Register callback for capture/compare events. */
 void tim_attach_cc_irq(TIM_TypeDef *tim, uint8_t ch, tim_cb_t cb, void *ctx) {
     if (ch == 0u || ch > 4u) return;
     uint8_t idx = tim_index(tim);
@@ -163,6 +176,7 @@ void tim_attach_cc_irq(TIM_TypeDef *tim, uint8_t ch, tim_cb_t cb, void *ctx) {
     }
 }
 
+/** Detach callback for update events. */
 void tim_detach_update_irq(TIM_TypeDef *tim) {
     uint8_t idx = tim_index(tim);
     if (idx == 0xFFu) return;
@@ -171,6 +185,7 @@ void tim_detach_update_irq(TIM_TypeDef *tim) {
     tim->DIER &= ~TIM_DIER_UIE;
 }
 
+/** Detach callback for capture/compare events. */
 void tim_detach_cc_irq(TIM_TypeDef *tim, uint8_t ch) {
     if (ch == 0u || ch > 4u) return;
     uint8_t idx = tim_index(tim);
@@ -180,6 +195,7 @@ void tim_detach_cc_irq(TIM_TypeDef *tim, uint8_t ch) {
     tim->DIER &= ~(1u << ch);
 }
 
+/** Dispatch timer interrupts to registered callbacks. */
 static void tim_irq_dispatch(TIM_TypeDef *tim) {
     uint8_t idx = tim_index(tim);
     if (idx == 0xFFu) return;
@@ -197,18 +213,26 @@ static void tim_irq_dispatch(TIM_TypeDef *tim) {
     }
 }
 
+/** TIM1 update and trigger interrupt handler. */
 void TIM1_BRK_UP_TRG_COM_IRQHandler(void) { tim_irq_dispatch(TIM1); }
+/** TIM2 global interrupt handler. */
 void TIM2_IRQHandler(void) { tim_irq_dispatch(TIM2); }
+/** TIM3 global interrupt handler. */
 void TIM3_IRQHandler(void) { tim_irq_dispatch(TIM3); }
+/** TIM14 global interrupt handler. */
 void TIM14_IRQHandler(void) { tim_irq_dispatch(TIM14); }
+/** TIM15 global interrupt handler. */
 void TIM15_IRQHandler(void) { tim_irq_dispatch(TIM15); }
+/** TIM16 global interrupt handler. */
 void TIM16_IRQHandler(void) { tim_irq_dispatch(TIM16); }
+/** TIM17 global interrupt handler. */
 void TIM17_IRQHandler(void) { tim_irq_dispatch(TIM17); }
 
 /* Último período medido pelo exemplo de captura (em contagens do timer) */
 volatile uint32_t tim_ic_last_period;
 
 /* Armazena o período entre capturas sucessivas e pisca PC9 */
+/** Callback computing period between captures and toggling LED. */
 static void tim_capture_cb(void *ctx) {
     (void)ctx;
     static uint32_t prev;
@@ -219,6 +243,7 @@ static void tim_capture_cb(void *ctx) {
 }
 
 /* Pisca PC8 a cada evento de atualização */
+/** Callback toggling LED on update events. */
 static void tim_blink_cb(void *ctx) {
     (void)ctx;
     gpio_toggle(GPIOC, 8);
@@ -231,6 +256,7 @@ static void tim_blink_cb(void *ctx) {
  * para controlar brilho de LED ou a velocidade de uma ventoinha.
  * Conecte um LED com resistor a PA6 para visualizar o PWM.
  */
+/** Example: generate PWM on TIM3 channel 1. */
 void tim_example_pwm(void) {
     gpio_config(GPIOA, 6, &(gpio_cfg_t){
         .mode = GPIO_MODE_AF,
@@ -262,6 +288,7 @@ void tim_example_pwm(void) {
  * captura. Para testar, alimente PA7 com um sinal quadrado de 0--3,3 V
  * (por exemplo, saída do gerador de funções ou do exemplo de PWM).
 */
+/** Example: input capture using TIM3 channel 2. */
 void tim_example_input_capture(void) {
     gpio_config(GPIOC, 9, &(gpio_cfg_t){
         .mode = GPIO_MODE_OUTPUT,
@@ -294,6 +321,7 @@ void tim_example_input_capture(void) {
  * (clock de 48 MHz). O callback pisca o LED conectado em PC8, mostrando como
  * usar o timer para tarefas periódicas.
  */
+/** Example: periodic update interrupt toggling PC8. */
 void tim_example_update_irq(void) {
     gpio_config(GPIOC, 8, &(gpio_cfg_t){
         .mode = GPIO_MODE_OUTPUT,
@@ -316,6 +344,7 @@ void tim_example_update_irq(void) {
  * O compare em 15 produz pulso de 1,5 ms (posição central). Ajuste entre 10 e
  * 20 para mover o servo.
  */
+/** Example: 50 Hz PWM for servo control. */
 void tim_example_servo_pwm(void) {
     gpio_config(GPIOB, 0, &(gpio_cfg_t){
         .mode = GPIO_MODE_AF,

--- a/stm32_repo/Drivers/tim.h
+++ b/stm32_repo/Drivers/tim.h
@@ -77,34 +77,46 @@ typedef struct {
 
 typedef void (*tim_cb_t)(void *ctx);
 
+/** Initialize a timer with basic configuration. */
 bool tim_init(TIM_TypeDef *tim, const tim_cfg_t *cfg);
+/** Enable or disable a timer. */
 void tim_enable(TIM_TypeDef *tim, bool en);
 
+/** Configure an output compare channel. */
 bool tim_config_output(TIM_TypeDef *tim, uint8_t ch, const tim_oc_cfg_t *cfg);
+/** Update compare value for an output channel. */
 void tim_set_compare(TIM_TypeDef *tim, uint8_t ch, uint32_t compare);
 
+/** Configure an input capture channel. */
 bool tim_config_input(TIM_TypeDef *tim, uint8_t ch, const tim_ic_cfg_t *cfg);
+/** Read captured value from a channel. */
 uint32_t tim_get_capture(TIM_TypeDef *tim, uint8_t ch);
 
+/** Enable or disable DMA requests for selected events. */
 void tim_enable_dma(TIM_TypeDef *tim, uint32_t mask, bool en);
 
+/** Register callback for update interrupt. */
 void tim_attach_update_irq(TIM_TypeDef *tim, tim_cb_t cb, void *ctx);
+/** Register callback for capture/compare interrupt. */
 void tim_attach_cc_irq(TIM_TypeDef *tim, uint8_t ch, tim_cb_t cb, void *ctx);
+/** Detach update interrupt callback. */
 void tim_detach_update_irq(TIM_TypeDef *tim);
+/** Detach capture/compare interrupt callback. */
 void tim_detach_cc_irq(TIM_TypeDef *tim, uint8_t ch);
 
 extern volatile uint32_t tim_ic_last_period;
 
 /* Exemplo: gera PWM no TIM3 canal 1 (PA6) */
+/** Example: generate PWM on TIM3 channel 1. */
 void tim_example_pwm(void);
 
-/* Exemplo: captura de entrada no TIM3 canal 2 (PA7) com LED em PC9 */
+/** Example: input capture on TIM3 channel 2. */
 void tim_example_input_capture(void);
 
-/* Exemplo: interrupção periódica via atualização do timer (pisca PC8) */
+/** Example: periodic update interrupt (blink LED). */
 void tim_example_update_irq(void);
 
-/* Exemplo: PWM de 50 Hz para servo no TIM3 canal 3 (PB0) */
+/** Example: servo control using PWM on TIM3 channel 3. */
 void tim_example_servo_pwm(void);
 
 #endif /* TIM_H */

--- a/stm32_repo/Drivers/usart.c
+++ b/stm32_repo/Drivers/usart.c
@@ -20,6 +20,7 @@ typedef struct {
     volatile uint32_t TDR;
 } USART_TypeDef_real;
 
+/** Convert generic USART pointer to register structure. */
 static inline USART_TypeDef_real *usart_real(USART_TypeDef *u) {
     return (USART_TypeDef_real *)u;
 }
@@ -50,6 +51,7 @@ static usart_it_state_t usart_it_state[4];
 static usart_dma_state_t usart_dma_state[4];
 static usart_irq_entry_t usart_irq_table[4];
 
+/** Translate USART instance to index. */
 static uint32_t usart_index(USART_TypeDef *u) {
     if (u == USART1) return 0u;
     if (u == USART2) return 1u;
@@ -58,10 +60,12 @@ static uint32_t usart_index(USART_TypeDef *u) {
     return 4u;
 }
 
+/** Obtain DMA channel index (1-based). */
 static uint8_t dma_channel_index(DMA_Channel_TypeDef *ch) {
     return (uint8_t)(ch - &DMA1->CH[0]) + 1u;
 }
 
+/** Initialize a USART peripheral. */
 bool usart_init(USART_TypeDef *usart, const usart_cfg_t *cfg) {
     if (!usart || !cfg || cfg->baudrate == 0u) {
         return false;
@@ -125,6 +129,7 @@ bool usart_init(USART_TypeDef *usart, const usart_cfg_t *cfg) {
     return true;
 }
 
+/** Enable or disable a USART. */
 void usart_enable(USART_TypeDef *usart, bool en) {
     if (!usart) return;
     USART_TypeDef_real *u = usart_real(usart);
@@ -135,6 +140,7 @@ void usart_enable(USART_TypeDef *usart, bool en) {
     }
 }
 
+/** Perform blocking transmit. */
 bool usart_write_poll(USART_TypeDef *usart, const uint8_t *data, size_t len) {
     if (!usart || (!data && len > 0u)) return false;
     USART_TypeDef_real *u = usart_real(usart);
@@ -145,6 +151,7 @@ bool usart_write_poll(USART_TypeDef *usart, const uint8_t *data, size_t len) {
     return true;
 }
 
+/** Perform blocking receive. */
 bool usart_read_poll(USART_TypeDef *usart, uint8_t *data, size_t len) {
     if (!usart || !data) return false;
     USART_TypeDef_real *u = usart_real(usart);
@@ -155,6 +162,7 @@ bool usart_read_poll(USART_TypeDef *usart, uint8_t *data, size_t len) {
     return true;
 }
 
+/** Start interrupt-driven transmit. */
 bool usart_write_it_start(USART_TypeDef *usart, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx) {
     if (!usart || !data || len == 0u) return false;
     uint32_t idx = usart_index(usart);
@@ -172,6 +180,7 @@ bool usart_write_it_start(USART_TypeDef *usart, const uint8_t *data, size_t len,
     return true;
 }
 
+/** Start interrupt-driven receive. */
 bool usart_read_it_start(USART_TypeDef *usart, uint8_t *data, size_t len, usart_cb_t cb, void *ctx) {
     if (!usart || !data || len == 0u) return false;
     uint32_t idx = usart_index(usart);
@@ -189,6 +198,7 @@ bool usart_read_it_start(USART_TypeDef *usart, uint8_t *data, size_t len, usart_
     return true;
 }
 
+/** DMA completion callback for USART transfers. */
 static void usart_dma_cb(void *ctx, uint32_t flags) {
     (void)flags;
     usart_dma_state_t *st = (usart_dma_state_t *)ctx;
@@ -201,6 +211,7 @@ static void usart_dma_cb(void *ctx, uint32_t flags) {
     }
 }
 
+/** Start DMA-driven transmit. */
 bool usart_write_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *tx_ch, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx) {
     if (!usart || !tx_ch || !data || len == 0u) return false;
     uint32_t idx = usart_index(usart);
@@ -222,6 +233,7 @@ bool usart_write_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *tx_ch, con
     return true;
 }
 
+/** Start DMA-driven reception. */
 bool usart_read_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *rx_ch, uint8_t *data, size_t len, usart_cb_t cb, void *ctx) {
     if (!usart || !rx_ch || !data || len == 0u) return false;
     uint32_t idx = usart_index(usart);
@@ -243,6 +255,7 @@ bool usart_read_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *rx_ch, uint
     return true;
 }
 
+/** Enable or disable DMA requests for RX/TX. */
 void usart_enable_dma(USART_TypeDef *usart, bool rx, bool tx) {
     if (!usart) return;
     USART_TypeDef_real *u = usart_real(usart);
@@ -252,6 +265,7 @@ void usart_enable_dma(USART_TypeDef *usart, bool rx, bool tx) {
     u->CR3 = cr3;
 }
 
+/** Enable selected USART interrupts. */
 void usart_enable_irq(USART_TypeDef *usart, uint32_t mask) {
     if (!usart) return;
     USART_TypeDef_real *u = usart_real(usart);
@@ -269,6 +283,7 @@ void usart_enable_irq(USART_TypeDef *usart, uint32_t mask) {
     }
 }
 
+/** Register generic interrupt callback. */
 bool usart_attach_irq(USART_TypeDef *usart, usart_irq_cb_t cb, void *ctx) {
     uint32_t idx = usart_index(usart);
     if (idx >= 4u) return false;
@@ -279,6 +294,7 @@ bool usart_attach_irq(USART_TypeDef *usart, usart_irq_cb_t cb, void *ctx) {
     return true;
 }
 
+/** Remove generic interrupt callback. */
 void usart_detach_irq(USART_TypeDef *usart) {
     uint32_t idx = usart_index(usart);
     if (idx >= 4u) return;
@@ -286,6 +302,7 @@ void usart_detach_irq(USART_TypeDef *usart) {
     usart_irq_table[idx].ctx = NULL;
 }
 
+/** Dispatch USART interrupts to handlers. */
 static void usart_irq_dispatch(uint32_t idx) {
     USART_TypeDef_real *u = usart_real(idx == 0u ? USART1 : (idx == 1u ? USART2 : (idx == 2u ? USART3 : USART4)));
     uint32_t isr = u->ISR;
@@ -315,8 +332,11 @@ static void usart_irq_dispatch(uint32_t idx) {
     }
 }
 
+/** USART1 global interrupt handler. */
 void USART1_IRQHandler(void) { usart_irq_dispatch(0u); }
+/** USART2 global interrupt handler. */
 void USART2_IRQHandler(void) { usart_irq_dispatch(1u); }
+/** Shared USART3/USART4 interrupt handler. */
 void USART3_4_IRQHandler(void) {
     usart_irq_dispatch(2u);
     usart_irq_dispatch(3u);

--- a/stm32_repo/Drivers/usart.h
+++ b/stm32_repo/Drivers/usart.h
@@ -60,8 +60,6 @@ typedef struct {
     enum usart_oversampling oversampling;
 } usart_cfg_t;
 
-typedef void (*usart_cb_t)(void *ctx);
-typedef void (*usart_irq_cb_t)(void *ctx, uint32_t isr);
 
 #define USART_IRQ_RXNE 0x1u
 #define USART_IRQ_TXE  0x2u
@@ -69,25 +67,44 @@ typedef void (*usart_irq_cb_t)(void *ctx, uint32_t isr);
 #define USART_IRQ_IDLE 0x8u
 #define USART_IRQ_PE   0x10u
 
-bool usart_init(USART_TypeDef *usart, const usart_cfg_t *cfg);
-void usart_enable(USART_TypeDef *usart, bool en);
-
-bool usart_write_poll(USART_TypeDef *usart, const uint8_t *data, size_t len);
-bool usart_read_poll(USART_TypeDef *usart, uint8_t *data, size_t len);
-
-bool usart_write_it_start(USART_TypeDef *usart, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
-bool usart_read_it_start(USART_TypeDef *usart, uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
-
-bool usart_write_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *tx_ch, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
-bool usart_read_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *rx_ch, uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
-
-void usart_enable_dma(USART_TypeDef *usart, bool rx, bool tx);
-void usart_enable_irq(USART_TypeDef *usart, uint32_t mask);
-bool usart_attach_irq(USART_TypeDef *usart, usart_irq_cb_t cb, void *ctx);
-void usart_detach_irq(USART_TypeDef *usart);
-
-void USART1_IRQHandler(void);
-void USART2_IRQHandler(void);
-void USART3_4_IRQHandler(void);
+/** Callback type for asynchronous USART operations. */
+typedef void (*usart_cb_t)(void *ctx);
+/** Callback type for raw ISR notifications. */
+typedef void (*usart_irq_cb_t)(void *ctx, uint32_t isr);
 
 #endif /* USART_H */
+/** Initialize a USART peripheral. */
+bool usart_init(USART_TypeDef *usart, const usart_cfg_t *cfg);
+/** Enable or disable USART. */
+void usart_enable(USART_TypeDef *usart, bool en);
+
+/** Blocking write operation. */
+bool usart_write_poll(USART_TypeDef *usart, const uint8_t *data, size_t len);
+/** Blocking read operation. */
+bool usart_read_poll(USART_TypeDef *usart, uint8_t *data, size_t len);
+
+/** Start interrupt-driven write. */
+bool usart_write_it_start(USART_TypeDef *usart, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
+/** Start interrupt-driven read. */
+bool usart_read_it_start(USART_TypeDef *usart, uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
+
+/** Start DMA-driven write. */
+bool usart_write_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *tx_ch, const uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
+/** Start DMA-driven read. */
+bool usart_read_dma_start(USART_TypeDef *usart, DMA_Channel_TypeDef *rx_ch, uint8_t *data, size_t len, usart_cb_t cb, void *ctx);
+
+/** Enable or disable DMA requests. */
+void usart_enable_dma(USART_TypeDef *usart, bool rx, bool tx);
+/** Enable specific USART interrupts. */
+void usart_enable_irq(USART_TypeDef *usart, uint32_t mask);
+/** Register a general USART interrupt callback. */
+bool usart_attach_irq(USART_TypeDef *usart, usart_irq_cb_t cb, void *ctx);
+/** Detach USART interrupt callback. */
+void usart_detach_irq(USART_TypeDef *usart);
+
+/** USART1 global interrupt handler. */
+void USART1_IRQHandler(void);
+/** USART2 global interrupt handler. */
+void USART2_IRQHandler(void);
+/** USART3 and USART4 combined interrupt handler. */
+void USART3_4_IRQHandler(void);


### PR DESCRIPTION
## Summary
- document driver APIs with Doxygen comments
- enable host-friendly ADC1 macro and stub Cortex-M0 helpers

## Testing
- `cd CMakeHost && rm -rf build && cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c060013924832493f4bbee107ec489