### PR TITLE
Add SPI SD card driver and tests

### DIFF
--- a/CMakeHost/tests/CMakeLists.txt
+++ b/CMakeHost/tests/CMakeLists.txt
@@ -106,3 +106,7 @@ add_test(NAME tmc2209 COMMAND test_tmc2209)
 add_executable(test_tmc2130 test_tmc2130.c)
 target_link_libraries(test_tmc2130 PRIVATE core)
 add_test(NAME tmc2130 COMMAND test_tmc2130)
+
+add_executable(test_sdcard test_sdcard.c)
+target_link_libraries(test_sdcard PRIVATE core)
+add_test(NAME sdcard COMMAND test_sdcard)

--- a/CMakeHost/tests/test_sdcard.c
+++ b/CMakeHost/tests/test_sdcard.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include "sdcard.h"
+#include "spi.h"
+
+static bool contains_cmd(uint8_t cmd) {
+    for (size_t i = 0; i < spi_stub_count(); ++i) {
+        if (spi_stub_get(i) == cmd) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int main(void) {
+    spi_cfg_t cfg = {
+        .mode = SPI_MODE_MASTER,
+        .direction = SPI_DIR_FULL_DUPLEX,
+        .cpol = SPI_CPOL_LOW,
+        .cpha = SPI_CPHA_1EDGE,
+        .datasize = 8u,
+        .first_bit = SPI_FIRST_MSB,
+        .nss = SPI_NSS_SOFT,
+        .crc_enable = false,
+        .crc_poly = 0u,
+    };
+    spi_init(SPI1, &cfg);
+    spi_enable(SPI1, true);
+    sdcard_t card;
+    spi_stub_reset();
+    assert(sdcard_init(&card, SPI1, NULL, 0u));
+    for (size_t i = 0; i < 10; ++i) {
+        assert(spi_stub_get(i) == 0xFF);
+    }
+    assert(contains_cmd(0x40)); /* CMD0 */
+    assert(contains_cmd(0x48)); /* CMD8 */
+    assert(contains_cmd(0x77)); /* CMD55 */
+    assert(contains_cmd(0x69)); /* ACMD41 */
+
+    uint8_t buf[512] = {0};
+    spi_stub_reset();
+    assert(sdcard_read_block(&card, 0x12345678u, buf));
+    assert(spi_stub_get(0) == 0x51); /* CMD17 */
+    assert(spi_stub_get(1) == 0x12);
+    assert(spi_stub_get(2) == 0x34);
+    assert(spi_stub_get(3) == 0x56);
+    assert(spi_stub_get(4) == 0x78);
+    assert(spi_stub_get(5) == 0xFF);
+
+    spi_stub_reset();
+    assert(sdcard_write_block(&card, 0x12345678u, buf));
+    assert(spi_stub_get(0) == 0x58); /* CMD24 */
+    assert(spi_stub_get(1) == 0x12);
+    assert(spi_stub_get(2) == 0x34);
+    assert(spi_stub_get(3) == 0x56);
+    assert(spi_stub_get(4) == 0x78);
+    assert(spi_stub_get(5) == 0xFF);
+    assert(spi_stub_get(7) == 0xFE); /* token */
+    assert(spi_stub_count() == 256);
+    return 0;
+}

--- a/stm32_repo/Drivers/sdcard.c
+++ b/stm32_repo/Drivers/sdcard.c
@@ -1,0 +1,118 @@
+#include "sdcard.h"
+
+#define CMD0   0x40u
+#define CMD8   0x48u
+#define CMD17  0x51u
+#define CMD24  0x58u
+#define CMD55  0x77u
+#define ACMD41 0x69u
+
+static void sdcard_cs(sdcard_t *sd, bool select) {
+    if (sd->cs_port) {
+        spi_cs_select(sd->cs_port, sd->cs_pin, select);
+    }
+}
+
+bool sdcard_init(sdcard_t *sd, SPI_TypeDef *spi, GPIO_TypeDef *cs_port, uint8_t cs_pin) {
+    if (!sd || !spi) {
+        return false;
+    }
+    sd->spi = spi;
+    sd->cs_port = cs_port;
+    sd->cs_pin = cs_pin;
+    if (cs_port) {
+        spi_cs_init(cs_port, cs_pin);
+        sdcard_cs(sd, false);
+    }
+    for (int i = 0; i < 10; ++i) {
+        spi_transfer(spi, 0xFFu);
+    }
+    sdcard_cs(sd, true);
+    spi_transfer(spi, CMD0);            /* GO_IDLE_STATE */
+    spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0);
+    spi_transfer(spi, 0x95u);
+    spi_transfer(spi, 0xFFu);
+    spi_transfer(spi, CMD8);            /* SEND_IF_COND */
+    spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0x01u); spi_transfer(spi, 0xAAu);
+    spi_transfer(spi, 0x87u);
+    for (int i = 0; i < 5; ++i) {
+        spi_transfer(spi, 0xFFu);
+    }
+    spi_transfer(spi, CMD55);           /* APP_CMD */
+    spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0);
+    spi_transfer(spi, 0xFFu);
+    spi_transfer(spi, 0xFFu);
+    spi_transfer(spi, ACMD41);          /* SD_SEND_OP_COND */
+    spi_transfer(spi, 0x40u); spi_transfer(spi, 0); spi_transfer(spi, 0); spi_transfer(spi, 0);
+    spi_transfer(spi, 0xFFu);
+    spi_transfer(spi, 0xFFu);
+    sdcard_cs(sd, false);
+    return true;
+}
+
+bool sdcard_read_block(sdcard_t *sd, uint32_t addr, uint8_t *buf) {
+    if (!sd || !buf) {
+        return false;
+    }
+    sdcard_cs(sd, true);
+    spi_transfer(sd->spi, CMD17);
+    spi_transfer(sd->spi, (uint8_t)(addr >> 24));
+    spi_transfer(sd->spi, (uint8_t)(addr >> 16));
+    spi_transfer(sd->spi, (uint8_t)(addr >> 8));
+    spi_transfer(sd->spi, (uint8_t)addr);
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFFu);
+    for (size_t i = 0; i < 512u; ++i) {
+        buf[i] = (uint8_t)spi_transfer(sd->spi, 0xFFu);
+    }
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFFu);
+    sdcard_cs(sd, false);
+    return true;
+}
+
+bool sdcard_write_block(sdcard_t *sd, uint32_t addr, const uint8_t *buf) {
+    if (!sd || !buf) {
+        return false;
+    }
+    sdcard_cs(sd, true);
+    spi_transfer(sd->spi, CMD24);
+    spi_transfer(sd->spi, (uint8_t)(addr >> 24));
+    spi_transfer(sd->spi, (uint8_t)(addr >> 16));
+    spi_transfer(sd->spi, (uint8_t)(addr >> 8));
+    spi_transfer(sd->spi, (uint8_t)addr);
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFEu);
+    for (size_t i = 0; i < 512u; ++i) {
+        spi_transfer(sd->spi, buf[i]);
+    }
+    spi_transfer(sd->spi, 0xFFu);
+    spi_transfer(sd->spi, 0xFFu);
+    sdcard_cs(sd, false);
+    return true;
+}
+
+void sdcard_example(void) {
+    spi_cfg_t cfg = {
+        .mode = SPI_MODE_MASTER,
+        .direction = SPI_DIR_FULL_DUPLEX,
+        .cpol = SPI_CPOL_LOW,
+        .cpha = SPI_CPHA_1EDGE,
+        .datasize = 8u,
+        .first_bit = SPI_FIRST_MSB,
+        .nss = SPI_NSS_SOFT,
+        .baudrate = SPI_BAUD_DIV8,
+        .crc_enable = false,
+        .crc_poly = 0u,
+    };
+    spi_init(SPI1, &cfg);
+    spi_enable(SPI1, true);
+    sdcard_t card;
+    sdcard_init(&card, SPI1, NULL, 0u);
+    uint8_t buffer[512];
+    sdcard_read_block(&card, 0u, buffer);
+    buffer[0] = 'S'; buffer[1] = 'D';
+    sdcard_write_block(&card, 0u, buffer);
+}

--- a/stm32_repo/Drivers/sdcard.h
+++ b/stm32_repo/Drivers/sdcard.h
@@ -1,0 +1,60 @@
+#ifndef SDCARD_H
+#define SDCARD_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "spi.h"
+#include "gpio.h"
+
+/** @file sdcard.h
+ *  @brief Driver simples para cartão SD em modo SPI.
+ */
+
+/** Estrutura de contexto para driver de cartão SD. */
+typedef struct {
+    SPI_TypeDef *spi;           /**< Periférico SPI utilizado */
+    GPIO_TypeDef *cs_port;      /**< Porta do pino CS (opcional) */
+    uint8_t cs_pin;             /**< Pino CS */
+} sdcard_t;
+
+/**
+ * @brief Inicializa o cartão SD no modo SPI.
+ *
+ * Envia a sequência padrão de reset e comandos básicos (CMD0, CMD8,
+ * CMD55/ACMD41).
+ *
+ * @param sd       Ponteiro para estrutura do driver.
+ * @param spi      Periférico SPI a ser utilizado.
+ * @param cs_port  Porta do pino CS (pode ser NULL para ignorar).
+ * @param cs_pin   Número do pino CS.
+ * @return true em caso de sucesso, false caso contrário.
+ */
+bool sdcard_init(sdcard_t *sd, SPI_TypeDef *spi, GPIO_TypeDef *cs_port, uint8_t cs_pin);
+
+/**
+ * @brief Lê um bloco de 512 bytes.
+ *
+ * @param sd   Ponteiro para driver inicializado.
+ * @param addr Endereço do bloco (endereçamento por bloco).
+ * @param buf  Buffer de 512 bytes para receber os dados.
+ * @return true se a operação foi iniciada, false caso contrário.
+ */
+bool sdcard_read_block(sdcard_t *sd, uint32_t addr, uint8_t *buf);
+
+/**
+ * @brief Escreve um bloco de 512 bytes.
+ *
+ * @param sd   Ponteiro para driver inicializado.
+ * @param addr Endereço do bloco (endereçamento por bloco).
+ * @param buf  Buffer de 512 bytes com os dados.
+ * @return true se a operação foi iniciada, false caso contrário.
+ */
+bool sdcard_write_block(sdcard_t *sd, uint32_t addr, const uint8_t *buf);
+
+/**
+ * @brief Exemplo de uso: inicializa, lê e grava o bloco 0.
+ */
+void sdcard_example(void);
+
+#endif /* SDCARD_H */


### PR DESCRIPTION
## Summary
- add SD card SPI driver with initialization and block read/write helpers
- include Doxygen documentation and usage example
- test driver command sequences via SPI stubs

## Testing
- `cd CMakeHost && cmake -B build -S .`
- `cmake --build build -j`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c1aa0e3b0c8324bdb85a129f2fb535