### PR TITLE
Add dynamic button debounce driver

### DIFF
--- a/CMakeHost/tests/CMakeLists.txt
+++ b/CMakeHost/tests/CMakeLists.txt
@@ -110,3 +110,7 @@ add_test(NAME tmc2130 COMMAND test_tmc2130)
 add_executable(test_sdcard test_sdcard.c)
 target_link_libraries(test_sdcard PRIVATE core)
 add_test(NAME sdcard COMMAND test_sdcard)
+
+add_executable(test_debounce test_debounce.c)
+target_link_libraries(test_debounce PRIVATE core)
+add_test(NAME debounce COMMAND test_debounce)

--- a/CMakeHost/tests/test_debounce.c
+++ b/CMakeHost/tests/test_debounce.c
@@ -1,0 +1,103 @@
+#include <assert.h>
+#include <stddef.h>
+#include "debounce.h"
+
+static bool input_state;
+
+static bool read_input(void *ctx) {
+    (void)ctx;
+    return input_state;
+}
+
+static int presses;
+static int releases;
+
+static void on_press(void *ctx) {
+    (void)ctx;
+    presses++;
+}
+
+static void on_release(void *ctx) {
+    (void)ctx;
+    releases++;
+}
+
+static void step(bool level) {
+    input_state = level;
+    debounce_process();
+}
+
+static void test_press_release(void) {
+    debounce_reset();
+    presses = 0;
+    releases = 0;
+    int id = debounce_add(read_input, NULL, on_press, on_release, NULL, 2);
+    assert(id >= 0);
+    /* Simulate bouncing on press */
+    step(true);
+    step(false);
+    step(true);
+    step(true);
+    step(true);
+    assert(presses == 1);
+    /* Simulate bouncing on release */
+    step(false);
+    step(true);
+    step(false);
+    step(false);
+    step(false);
+    assert(releases == 1);
+}
+
+/* Second test: add two inputs, remove one, ensure callbacks only for remaining */
+static bool input2_state;
+static int presses2;
+
+static bool read_input2(void *ctx) {
+    (void)ctx;
+    return input2_state;
+}
+
+static void on_press2(void *ctx) {
+    (void)ctx;
+    presses2++;
+}
+
+static void test_add_remove(void) {
+    debounce_reset();
+    presses = presses2 = 0;
+    int id1 = debounce_add(read_input, NULL, on_press, NULL, NULL, 1);
+    int id2 = debounce_add(read_input2, NULL, on_press2, NULL, NULL, 1);
+    assert(id1 >= 0 && id2 >= 0 && id1 != id2);
+
+    /* Trigger press on both inputs */
+    input_state = true;
+    input2_state = true;
+    debounce_process();
+    debounce_process();
+    assert(presses == 1);
+    assert(presses2 == 1);
+
+    /* Remove first input and toggle it a few times */
+    assert(debounce_remove(id1));
+    input_state = false;
+    debounce_process();
+    input_state = true;
+    debounce_process();
+    assert(presses == 1);
+
+    /* Second input should still respond */
+    input2_state = false;
+    debounce_process();
+    debounce_process();
+    input2_state = true;
+    debounce_process();
+    debounce_process();
+    assert(presses2 == 2);
+}
+
+int main(void) {
+    test_press_release();
+    test_add_remove();
+    return 0;
+}

--- a/stm32_repo/Drivers/debounce.c
+++ b/stm32_repo/Drivers/debounce.c
@@ -1,0 +1,112 @@
+/*
+ * Dynamic software debouncer for digital inputs.
+ *
+ * The driver itself does not perform timing. The application must call
+ * debounce_process() at a fixed rate—typically from a SysTick handler,
+ * periodic timer interrupt, or the main loop. The `ticks` parameter of
+ * debounce_add() specifies how many consecutive samples are required to
+ * validate a state change. The effective debounce time corresponds to
+ * `ticks` multiplied by the interval between calls to debounce_process().
+ */
+#include "debounce.h"
+#include <stdlib.h>
+
+#ifndef DEBOUNCE_DEFAULT_TICKS
+#define DEBOUNCE_DEFAULT_TICKS 5u
+#endif
+
+typedef struct {
+    int id;
+    debounce_read_fn read;
+    void *read_ctx;
+    debounce_cb_t on_press;
+    debounce_cb_t on_release;
+    void *cb_ctx;
+    bool stable_state;
+    bool last_sample;
+    uint8_t counter;
+    uint8_t threshold;
+} debounce_entry_t;
+
+static debounce_entry_t *entries;
+static size_t entry_count;
+static int next_id;
+
+void debounce_reset(void) {
+    free(entries);
+    entries = NULL;
+    entry_count = 0;
+    next_id = 0;
+}
+
+int debounce_add(debounce_read_fn read, void *read_ctx,
+                 debounce_cb_t on_press, debounce_cb_t on_release,
+                 void *cb_ctx, uint8_t ticks) {
+    if (!read) {
+        return -1;
+    }
+    debounce_entry_t *tmp = realloc(entries, (entry_count + 1u) * sizeof(*entries));
+    if (!tmp) {
+        return -1;
+    }
+    entries = tmp;
+    debounce_entry_t *e = &entries[entry_count];
+    e->id = next_id++;
+    e->read = read;
+    e->read_ctx = read_ctx;
+    e->on_press = on_press;
+    e->on_release = on_release;
+    e->cb_ctx = cb_ctx;
+    e->stable_state = e->last_sample = read(read_ctx);
+    e->counter = 0u;
+    e->threshold = ticks ? ticks : DEBOUNCE_DEFAULT_TICKS;
+    entry_count++;
+    return e->id;
+}
+
+bool debounce_remove(int id) {
+    for (size_t i = 0; i < entry_count; ++i) {
+        if (entries[i].id == id) {
+            for (size_t j = i + 1; j < entry_count; ++j) {
+                entries[j - 1] = entries[j];
+            }
+            entry_count--;
+            if (entry_count == 0) {
+                free(entries);
+                entries = NULL;
+            } else {
+                debounce_entry_t *tmp = realloc(entries, entry_count * sizeof(*entries));
+                if (tmp) {
+                    entries = tmp;
+                }
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+void debounce_process(void) {
+    for (size_t i = 0; i < entry_count; ++i) {
+        debounce_entry_t *e = &entries[i];
+        bool sample = e->read(e->read_ctx);
+        if (sample != e->last_sample) {
+            e->last_sample = sample;
+            e->counter = 0u;
+        } else if (e->counter < e->threshold) {
+            e->counter++;
+        }
+        if (e->counter >= e->threshold && sample != e->stable_state) {
+            e->stable_state = sample;
+            if (sample) {
+                if (e->on_press) {
+                    e->on_press(e->cb_ctx);
+                }
+            } else {
+                if (e->on_release) {
+                    e->on_release(e->cb_ctx);
+                }
+            }
+        }
+    }
+}

--- a/stm32_repo/Drivers/debounce.h
+++ b/stm32_repo/Drivers/debounce.h
@@ -1,0 +1,75 @@
+#ifndef DEBOUNCE_H
+#define DEBOUNCE_H
+
+/**
+ * @file debounce.h
+ * @brief Runtime-configurable software debouncer for digital inputs.
+ *
+ * The module does not manage any hardware timer. The application is
+ * responsible for calling ::debounce_process() at a constant rate. The
+ * number of successive samples required to accept a transition is
+ * configured through the `ticks` parameter of ::debounce_add(). The
+ * resulting debounce interval is `ticks` multiplied by the period
+ * between calls to ::debounce_process().
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Function to read current level of input. Should return true when pressed. */
+typedef bool (*debounce_read_fn)(void *ctx);
+
+/** Callback invoked on press or release events. */
+typedef void (*debounce_cb_t)(void *ctx);
+
+/**
+ * @brief Add a new input to debounce manager.
+ *
+ * @param read       Function used to sample the input.
+ * @param read_ctx   Context pointer passed to read function.
+ * @param on_press   Callback invoked when the input becomes pressed.
+ * @param on_release Callback invoked when the input becomes released.
+ * @param cb_ctx     Context pointer passed to callbacks.
+ * @param ticks      Number of consecutive samples required to validate
+ *                   a change. The effective debounce time corresponds to
+ *                   `ticks` multiplied by the period between consecutive
+ *                   calls to ::debounce_process(). If zero, a default
+ *                   value is used.
+ * @return Identifier of the new input, or -1 on failure.
+ */
+int debounce_add(debounce_read_fn read, void *read_ctx,
+                 debounce_cb_t on_press, debounce_cb_t on_release,
+                 void *cb_ctx, uint8_t ticks);
+
+/**
+ * @brief Remove an input previously added.
+ * @param id Identifier returned by debounce_add.
+ * @return true on success, false if id not found.
+ */
+bool debounce_remove(int id);
+
+/**
+ * @brief Process all registered inputs.
+ *
+ * Call this function periodically at a fixed rate to perform debouncing.
+ * Typical usage is from a SysTick handler, timer interrupt or the main
+ * execution loop. The sampling period established by this call frequency
+ * is used together with the `ticks` threshold to determine the total
+ * debounce time for each input.
+ */
+void debounce_process(void);
+
+/**
+ * @brief Remove all inputs and release resources.
+ */
+void debounce_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEBOUNCE_H */


### PR DESCRIPTION
## Summary
- implement dynamic debounce driver with runtime addition/removal of inputs
- add unit tests verifying debounce handling and callbacks
- document timing requirements within the driver source instead of README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c1d05e688c832495fdf119b79c1bf0